### PR TITLE
Fix N+1 queries problem

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,7 @@
 class Post < ApplicationRecord
     belongs_to :user
     has_many :likes , dependent: :destroy
-    has_many :comments , dependent: :destroy
+    has_many :comments, -> { order(created_at: :desc) }, dependent: :destroy
     def liked?(user)
         !!self.likes.find{|like| like.user_id == user.id}
     end

--- a/app/views/layouts/_commentSection.html.erb
+++ b/app/views/layouts/_commentSection.html.erb
@@ -1,7 +1,7 @@
 
 
 
-<% obj.comments.reverse.each do |c| %>
+<% comments.each do |c| %>
 
   
 <div class="row">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -9,7 +9,7 @@
 
     <%if @post.comments.count != 0 %>
 
-<%= render "layouts/commentSection" , obj:@post%>
+<%= render "layouts/commentSection" , comments: @post.comments.includes(:user) %>
 <%else%>
 <%= render "layouts/nocomments" , obj:@post%>
 <%end%>


### PR DESCRIPTION
While fetching the [user who made the comments](https://github.com/NITK-KODE/popcorn/blob/main/app/views/layouts/_commentSection.html.erb#L9) N+1 queries are being made. This could instead be replaced with just 2 queries.